### PR TITLE
Move versions to properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,5 @@ This project generates an uber JAR from Groovy JARs similar to the the `groovy-a
 
 ### Steps to publish
 
-- Update `groovyVersion` in `build.gradle`.
-- `git tag -a ${tagName} -m 'Upgrade to Groovy X.Y.Z'`
-- Run `git describe --dirty --abbrev=7` to verify it outputs `$tagName`, something like `1.1`, not `1.0-9-gbba51f1`.
-- `git push --tags`
-- Run [the TC job](https://builds.gradle.org/viewType.html?buildTypeId=GradleGroovy_GradleGroovyAllPublishing) (this job will run `./gradlew publish -Prelease -PartifactoryUser=<username> -PartifactoryPassword=<password>`)
+- Update the version in `gradle.properties`
+- Run [the TC job](https://builds.gradle.org/viewType.html?buildTypeId=GradleGroovy_GradleGroovyAllPublishing) (this job will run `./gradlew publish -Prelease -PgroovyVersoin=2.5.7 -PgradleGroovyAllVersion=1.0 -PartifactoryUser=<username> -PartifactoryPassword=<password>`)

--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,6 @@ def gradleGroovyAllVersion = getProperty("gradleGroovyAllVersion")
 def release = hasProperty("release")
 def snapshot = groovyVersion.endsWith("-SNAPSHOT")
 
-if(!release && !snapshot) {
-    throw new RuntimeException("To release a non-snapshot version, use -Prelease")
-}
-
 group = "org.gradle.groovy"
 version = "$gradleGroovyAllVersion-$groovyVersion"
 description "Replacement for groovy-all.jar discontinued in Groovy 2.5"

--- a/build.gradle
+++ b/build.gradle
@@ -7,27 +7,17 @@ plugins {
 }
 
 def groovyVersion = getProperty("groovyVersion")
-
-/*
- * Change base version by applying a Git tag.
- *
- * Release snapshot version with ./gradlew publish -Prelease
- * Release final version with ./gradlew publish -Prelease=final
- */
+def gradleGroovyAllVersion = getProperty("gradleGroovyAllVersion")
 
 def release = hasProperty("release")
 def snapshot = groovyVersion.endsWith("-SNAPSHOT")
 
-def gitVersion = ["git", "describe", "--dirty", "--abbrev=${snapshot ? 0 : 7}"].execute().text.trim()
-if (release && gitVersion.contains("dirty")) {
-    throw new RuntimeException("Cannot release a dirty version")
-}
-if (release && !snapshot && gitVersion.contains("-")) {
-    throw new RuntimeException("Cannot release an untagged version")
+if(!release && !snapshot) {
+    throw new RuntimeException("To release a non-snapshot version, use -Prelease")
 }
 
 group = "org.gradle.groovy"
-version = "$gitVersion-$groovyVersion"
+version = "$gradleGroovyAllVersion-$groovyVersion"
 description "Replacement for groovy-all.jar discontinued in Groovy 2.5"
 
 println "The version is: $version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+groovyVersion=2.5.7
+gradleGroovyAllVersion=1.0


### PR DESCRIPTION
This PR creates two properties in `gradle.properties` file:

- `groovyVersion`
- `gradleGroovyAllVersion`

From https://github.com/gradle/ci-health/blob/cff9a8ba96e16114d47714443c570ac73fb259f1/gradle.properties#L4 I think putting version into `gradle.properties` is a very good practice. So I prefer the properties files over arguments in TC jobs.