### PR TITLE
Remove duplicates from final artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,29 +71,34 @@ task configureGroovyAll {
         ]
 
         def findDuplicates = { List<FileTree> fileForest ->
-            Map<String, List<File>> duplicates = [:].withDefault { [] }
+            Map<String, List<File>> filesByRelativePath = [:].withDefault { [] }
             fileForest*.visit([
                 visitDir : {},
-                visitFile: { duplicates[it.relativePath.toString()] << it.file }
+                visitFile: { filesByRelativePath[it.relativePath.toString()] << it.file }
             ] as FileVisitor)
-            duplicates.findAll { it.value.size() > 1 }
+            filesByRelativePath.findAll { it.value.size() > 1 }
+        }
+
+        def concatenate = { List<File> files -> files*.text.join('\n') }
+
+        def joinValues = { String properties, String keyName ->
+            (properties =~ /$keyName\s*=\s*(.+)/)*.getAt(1).join(',')
         }
 
         def mergeFiles = { String relative, List<File> files ->
-            def concatenatedFiles = files*.text.join('\n')
             switch (relative) {
                 case toMerge.LICENSE:
                 case toMerge.NOTICE:
                 case toMerge.AST_TRANSFORMATION:
-                    return concatenatedFiles
+                    return concatenate(files)
                 case toMerge.GROOVY_RELEASE_INFO_PROPERTIES:
                     return files[0].text
                 case toMerge.EXTENSION_MODULE:
                     return """
                         moduleName=groovy-all
-                        moduleVersion=${(files[0].text =~ /moduleVersion=(.+)/)[0][1]}
-                        extensionClasses=${(concatenatedFiles =~ /extensionClasses=(.+)/)*.getAt(1).join(',')}
-                        staticExtensionClasses=${(concatenatedFiles =~ /staticExtensionClasses=(.+)/)*.getAt(1).join(',')}
+                        moduleVersion=${joinValues(files[0].text, 'moduleVersion')}
+                        extensionClasses=${joinValues(concatenate(files), 'extensionClasses')}
+                        staticExtensionClasses=${joinValues(concatenate(files), 'staticExtensionClasses')}
                     """.stripIndent().trim()
                 case toMerge.MANIFEST_MF:
                 case toMerge.INDEX_LIST:

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import groovy.io.FileType
 import org.gradle.util.VersionNumber
 
 plugins {
@@ -26,7 +27,7 @@ buildScan {
 
 allprojects {
     repositories {
-    	mavenCentral()
+        mavenCentral()
         maven { url = "https://oss.jfrog.org/artifactory/oss-snapshot-local" }
     }
 }
@@ -41,7 +42,7 @@ configurations {
 dependencies {
     groovy group: "org.codehaus.groovy", name: "groovy-all", version: groovyVersion
     if (VersionNumber.parse(groovyVersion) >= VersionNumber.parse("2.5.0")) {
-       groovy group: "org.codehaus.groovy", name: "groovy-dateutil", version: groovyVersion
+        groovy group: "org.codehaus.groovy", name: "groovy-dateutil", version: groovyVersion
     }
 }
 
@@ -59,57 +60,81 @@ task configureGroovyAll {
     inputs.files configurations.groovy
 
     doFirst {
-        def extensionClasses = []
-        def staticExtensionClasses = []
+        def toMerge = [
+            'LICENSE'                       : 'META-INF/LICENSE',
+            'NOTICE'                        : 'META-INF/NOTICE',
+            'AST_TRANSFORMATION'            : 'META-INF/services/org.codehaus.groovy.transform.ASTTransformation',
+            'EXTENSION_MODULE'              : 'META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule',
+            'GROOVY_RELEASE_INFO_PROPERTIES': 'META-INF/groovy-release-info.properties',
+            'GROOVY_RUNNER'                 : 'META-INF/services/org.apache.groovy.plugin.GroovyRunner',
+            'INDEX_LIST'                    : 'META-INF/INDEX.LIST',
+            'MANIFEST_MF'                   : 'META-INF/MANIFEST.MF'
+        ]
+
+        def collectDuplicates = { File[] roots ->
+            Map<String, List<File>> duplicates = [:].withDefault { [] }
+            roots.each { root ->
+                root.eachFileRecurse(FileType.FILES) {
+                    def relative = root.toURI().relativize(it.toURI())
+                    duplicates[relative.toString()] += it
+                }
+            }
+            return duplicates.findAll { it.value.size() > 1 }
+        }
+
+        def merge = { String relative, List<File> files ->
+            switch (relative) {
+                case [toMerge.LICENSE, toMerge.NOTICE, toMerge.AST_TRANSFORMATION]:
+                    return files*.text.join("\n")
+                case [toMerge.GROOVY_RELEASE_INFO_PROPERTIES]:
+                    return files[0].text
+                case toMerge.EXTENSION_MODULE:
+                    return """
+                        moduleName=groovy-all
+                        moduleVersion=${(files[0].text =~ /moduleVersion=(.+)/)[0][1]}
+                        extensionClasses=${(files*.text.join('\n') =~ /extensionClasses=(.+)/)*.getAt(1).toSet().join(',')}
+                        staticExtensionClasses=${(files*.text.join('\n') =~ /staticExtensionClasses=(.+)/)*.getAt(1).toSet().join(',')}
+                    """.stripIndent().trim()
+                case [toMerge.MANIFEST_MF, toMerge.INDEX_LIST, toMerge.GROOVY_RUNNER]:
+                    return null
+                default:
+                    throw new IllegalThreadStateException(files.toString())
+            }
+        }
 
         tasks.groovyAll {
             from writeVersionProperties
 
-            configurations.groovy.filter { it.name ==~ /groovy-.*\.jar/ }.each { groovyJar ->
-                def extractedFiles = zipTree(groovyJar)
+            configurations.groovy
+                .filter { it.name ==~ /groovy-.*\.jar/ }
+                .collect { zipTree(it) }
+                .each { tree ->
+                    tree.files /* extract archives */
 
-                extractedFiles.filter { it.name == "org.codehaus.groovy.runtime.ExtensionModule" }.each { extensionModuleFile ->
-                    def extensionModule = new Properties()
-                    extensionModuleFile.withInputStream { input ->
-                        extensionModule.load(input)
-                    }
-                    extensionClasses << extensionModule.extensionClasses
-                    staticExtensionClasses << extensionModule.staticExtensionClasses
+                    def expandedArchives = new File("${buildDir}/tmp/expandedArchives")
+                    def mergedFolder = new File(expandedArchives, 'merged')
+                    collectDuplicates(expandedArchives.listFiles())
+                        .each { String relative, List<File> files ->
+                            def mergedFile = new File(mergedFolder, relative)
+                            def content = merge(relative, files)
+                            if (content != null) {
+                                mergedFile.parentFile.mkdirs()
+                                mergedFile.text = content
+                            }
+                        }
+
+                    from(mergedFolder)
+                    from(tree) { exclude toMerge.values() }
                 }
-
-                from(extractedFiles) {
-                    exclude { it.path == "META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule" }
-                }
-                manifest.from extractedFiles.find { it.name == "MANIFEST.MF" }
-            }
-
-            def extensionsModuleFile = file("${buildDir}/tmp/org.codehaus.groovy.runtime.ExtensionModule")
-
-            def extensnionModuleProperties = new Properties()
-            extensnionModuleProperties["moduleName"] = "groovy-all"
-            extensnionModuleProperties["moduleVersion"] = groovyVersion
-            extensnionModuleProperties["extensionClasses"] = extensionClasses.join(",")
-            extensnionModuleProperties["staticExtensionClasses"] = staticExtensionClasses.join(",")
-
-            delete(extensionsModuleFile)
-            mkdir(extensionsModuleFile.parentFile)
-            extensionsModuleFile.withOutputStream { out ->
-                extensnionModuleProperties.store(out, null)
-            }
-
-            from(extensionsModuleFile) {
-                into("META-INF/groovy")
-            }
         }
     }
 }
 
 task groovyAll(type: Jar) {
     dependsOn configureGroovyAll
-    // Keep all licenses and ExtensionModules
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    baseName = "groovy-all"
-    destinationDir = file("build/artifacts/jar")
+    duplicatesStrategy = DuplicatesStrategy.FAIL
+    archiveBaseName = "groovy-all"
+    destinationDirectory = file("build/artifacts/jar")
 }
 
 task download {

--- a/build.gradle
+++ b/build.gradle
@@ -80,17 +80,18 @@ task configureGroovyAll {
         }
 
         def mergeFiles = { String relative, List<File> files ->
+            def concatenatedFiles = files*.text.join('\n')
             switch (relative) {
                 case [toMerge.LICENSE, toMerge.NOTICE, toMerge.AST_TRANSFORMATION]:
-                    return files*.text.join("\n")
+                    return concatenatedFiles
                 case [toMerge.GROOVY_RELEASE_INFO_PROPERTIES]:
                     return files[0].text
                 case toMerge.EXTENSION_MODULE:
                     return """
                         moduleName=groovy-all
                         moduleVersion=${(files[0].text =~ /moduleVersion=(.+)/)[0][1]}
-                        extensionClasses=${(files*.text.join('\n') =~ /extensionClasses=(.+)/)*.getAt(1).toSet().join(',')}
-                        staticExtensionClasses=${(files*.text.join('\n') =~ /staticExtensionClasses=(.+)/)*.getAt(1).toSet().join(',')}
+                        extensionClasses=${(concatenatedFiles =~ /extensionClasses=(.+)/)*.getAt(1).join(',')}
+                        staticExtensionClasses=${(concatenatedFiles =~ /staticExtensionClasses=(.+)/)*.getAt(1).join(',')}
                     """.stripIndent().trim()
                 case [toMerge.MANIFEST_MF, toMerge.INDEX_LIST, toMerge.GROOVY_RUNNER]:
                     return null

--- a/build.gradle
+++ b/build.gradle
@@ -82,9 +82,11 @@ task configureGroovyAll {
         def mergeFiles = { String relative, List<File> files ->
             def concatenatedFiles = files*.text.join('\n')
             switch (relative) {
-                case [toMerge.LICENSE, toMerge.NOTICE, toMerge.AST_TRANSFORMATION]:
+                case toMerge.LICENSE:
+                case toMerge.NOTICE:
+                case toMerge.AST_TRANSFORMATION:
                     return concatenatedFiles
-                case [toMerge.GROOVY_RELEASE_INFO_PROPERTIES]:
+                case toMerge.GROOVY_RELEASE_INFO_PROPERTIES:
                     return files[0].text
                 case toMerge.EXTENSION_MODULE:
                     return """
@@ -93,7 +95,9 @@ task configureGroovyAll {
                         extensionClasses=${(concatenatedFiles =~ /extensionClasses=(.+)/)*.getAt(1).join(',')}
                         staticExtensionClasses=${(concatenatedFiles =~ /staticExtensionClasses=(.+)/)*.getAt(1).join(',')}
                     """.stripIndent().trim()
-                case [toMerge.MANIFEST_MF, toMerge.INDEX_LIST, toMerge.GROOVY_RUNNER]:
+                case toMerge.MANIFEST_MF:
+                case toMerge.INDEX_LIST:
+                case toMerge.GROOVY_RUNNER:
                     return null
                 default:
                     throw new IllegalThreadStateException(files.toString())

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-import groovy.io.FileType
 import org.gradle.util.VersionNumber
 
 plugins {
@@ -71,18 +70,16 @@ task configureGroovyAll {
             'MANIFEST_MF'                   : 'META-INF/MANIFEST.MF'
         ]
 
-        def collectDuplicates = { File[] roots ->
+        def findDuplicates = { List<FileTree> fileForest ->
             Map<String, List<File>> duplicates = [:].withDefault { [] }
-            roots.each { root ->
-                root.eachFileRecurse(FileType.FILES) {
-                    def relative = root.toURI().relativize(it.toURI())
-                    duplicates[relative.toString()] += it
-                }
-            }
-            return duplicates.findAll { it.value.size() > 1 }
+            fileForest*.visit([
+                visitDir : {},
+                visitFile: { duplicates[it.relativePath.toString()] << it.file }
+            ] as FileVisitor)
+            duplicates.findAll { it.value.size() > 1 }
         }
 
-        def merge = { String relative, List<File> files ->
+        def mergeFiles = { String relative, List<File> files ->
             switch (relative) {
                 case [toMerge.LICENSE, toMerge.NOTICE, toMerge.AST_TRANSFORMATION]:
                     return files*.text.join("\n")
@@ -102,30 +99,34 @@ task configureGroovyAll {
             }
         }
 
+        def mergeDuplicates = { FileTree tree, Map<String, List<File>> duplicates ->
+            def mergedFolder = new File(tree.tree.tmpDir, 'merged')
+            duplicates.each { relative, files ->
+                def mergedFile = new File(mergedFolder, relative)
+                def content = mergeFiles(relative, files)
+                if (content != null) {
+                    mergedFile.parentFile.mkdirs()
+                    mergedFile.text = content
+                }
+            }
+            mergedFolder
+        }
+
         tasks.groovyAll {
             from writeVersionProperties
 
-            configurations.groovy
+            def fileForest = configurations.groovy
                 .filter { it.name ==~ /groovy-.*\.jar/ }
                 .collect { zipTree(it) }
-                .each { tree ->
-                    tree.files /* extract archives */
 
-                    def expandedArchives = new File("${buildDir}/tmp/expandedArchives")
-                    def mergedFolder = new File(expandedArchives, 'merged')
-                    collectDuplicates(expandedArchives.listFiles())
-                        .each { String relative, List<File> files ->
-                            def mergedFile = new File(mergedFolder, relative)
-                            def content = merge(relative, files)
-                            if (content != null) {
-                                mergedFile.parentFile.mkdirs()
-                                mergedFile.text = content
-                            }
-                        }
+            def duplicates = findDuplicates(fileForest)
 
-                    from(mergedFolder)
-                    from(tree) { exclude toMerge.values() }
-                }
+            fileForest.each { tree ->
+                from(tree) { exclude toMerge.values() }
+
+                def mergedFolder = mergeDuplicates(tree, duplicates)
+                from(mergedFolder)
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -112,9 +112,9 @@ task configureGroovyAll {
         def mergeDuplicates = { FileTree tree, Map<String, List<File>> duplicates ->
             def mergedFolder = new File(tree.tree.tmpDir, 'merged')
             duplicates.each { relative, files ->
-                def mergedFile = new File(mergedFolder, relative)
                 def content = mergeFiles(relative, files)
                 if (content != null) {
+                    def mergedFile = new File(mergedFolder, relative)
                     mergedFile.parentFile.mkdirs()
                     mergedFile.text = content
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-groovyVersion=2.5.7
+groovyVersion=2.5.4
 gradleGroovyAllVersion=1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 groovyVersion=2.5.4
-gradleGroovyAllVersion=1.0
+gradleGroovyAllVersion=1.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jul 23 15:06:18 CEST 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/10038

Previously the `Manifest.mf` was overwritten by the first entry manually and the `ExtensionModule` property files were parsed, processed, merged and written back.

Now we're excluding certain files and recreating them in a different folder and adding them as a sources to avoid duplication.

The manifest file is ignored (and recreated by the jar task as a minimal manifest file), the license, notice and ast transformations are simply appended to each other, separately, the groovy release info was the same, kept only a single version, and the index list and groovy runner are excluded.

Before:
<img src="https://user-images.githubusercontent.com/1841944/61730577-f84db100-ad79-11e9-9918-5dcf4bdde25c.png">

After:
<img src="https://user-images.githubusercontent.com/1841944/61730591-fe439200-ad79-11e9-9500-65f7f211fe3b.png">